### PR TITLE
[11024] fix: remove the ref from the checkout action

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -33,8 +33,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Clone License Check Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
## Describe your changes
- Remove the ref from the checkout action due to the wrong repository reference when PR from external fork.

## Issue ticket number and link
AB#1124

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
