### PR TITLE
fix: license checkout action and split the checker and notice file update

### DIFF
--- a/.github/workflows/check-notice-file.yml
+++ b/.github/workflows/check-notice-file.yml
@@ -16,26 +16,21 @@ name: Check licenses
 
 on:
   workflow_dispatch:
-  workflow_call:
-  push:
-    # Run only on branches/commits and not tags
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
+    types: [closed]
 
 jobs:
-  check-licenses:
+  pr_merged:
+    # Check and generate a new Noticefile only if the PR state is merged
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    name: Check Software Licenses
+    name: Check Software Licenses and Notice file
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
           ref: ${{ github.head_ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       - name: Clone License Check Repo
         uses: actions/checkout@v2
@@ -44,9 +39,9 @@ jobs:
           ref: v1
           path: .github/actions/license-check
 
-      - name: Run License Checker
+      - name: Run License Checker and Check the Notice file
         uses: ./.github/actions/license-check
         with:
           config-file-path: ./.licensechecker.yml
           fail-on-violation: false
-          generate-notice-file: false
+          notice-file-name: "NOTICE-3RD-PARTY-CONTENT"

--- a/.github/workflows/update-notice-file.yml
+++ b/.github/workflows/update-notice-file.yml
@@ -24,7 +24,7 @@ jobs:
     # Check and generate a new Noticefile only if the PR state is merged
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    name: Check Software Licenses and Notice file
+    name: Check and update Licenses Notice file
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/update-notice-file.yml
+++ b/.github/workflows/update-notice-file.yml
@@ -12,7 +12,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Check licenses
+name: Update license notice file
 
 on:
   workflow_dispatch:

--- a/.github/workflows/update-notice-file.yml
+++ b/.github/workflows/update-notice-file.yml
@@ -39,7 +39,7 @@ jobs:
           ref: v1
           path: .github/actions/license-check
 
-      - name: Run License Checker and Check the Notice file
+      - name: Run License Checker to update the notice file
         uses: ./.github/actions/license-check
         with:
           config-file-path: ./.licensechecker.yml


### PR DESCRIPTION
- Fix the Github checkout action to include the repository 
- Split the license checker from the notice file update in multiple workflows 

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
