### PR TITLE
fix: trigger the notice file update only from the push event and remove PR

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -16,11 +16,6 @@ name: Check licenses
 
 on:
   workflow_dispatch:
-  workflow_call:
-  push:
-    # Run only on branches/commits and not tags
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/update-notice-file.yml
+++ b/.github/workflows/update-notice-file.yml
@@ -16,13 +16,13 @@ name: Update license notice file
 
 on:
   workflow_dispatch:
-  pull_request:
-    types: [closed]
+  push:
+    # Run only on branches/commits and not tags
+    branches:
+      - main
 
 jobs:
-  pr_merged:
-    # Check and generate a new Noticefile only if the PR state is merged
-    if: github.event.pull_request.merged == true
+  update_notice_file:
     runs-on: ubuntu-latest
     name: Check and update Licenses Notice file
 


### PR DESCRIPTION
## Describe your changes
- Trigger the notice file update only from the Github push to main branch event and not from the PR anymore.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
- [ ] Do we need to implement analytics?
- [x] Will this be part of a product update? If yes, please write one phrase about this update.
